### PR TITLE
Fix issue with ie9

### DIFF
--- a/addon/mixins/csp-style.js
+++ b/addon/mixins/csp-style.js
@@ -48,6 +48,10 @@ var StyleObserver = Ember.Object.extend({
 		if (!(value instanceof Ember.Handlebars.SafeString)) {
 			value = Ember.Handlebars.Utils.escapeExpression(value);
 		}
+		// ie9 gets upset if value is 'NaN'
+		if (value === 'NaN') {
+			value = '';
+		}
 		// set the property
 		if (value != null)
 		{


### PR DESCRIPTION
ie9 throws `Invalid Argument` instead of ignoring if `value` is `NaN`

I would feel like the consuming app should make sure it doesn't feed this addon a `NaN`, except that it only occurs on ie9, so it's a pretty big surprise if you weren't developing against ie9. Also, it's hard to track down the source of the bug, because the error that ie9 throws is not very helpful.