### PR TITLE
Upgrading ember-string-ishtmlsafe-polyfill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 

--- a/addon/mixins/observers/style.js
+++ b/addon/mixins/observers/style.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 export default Ember.Object.extend({
 	target: null,
@@ -44,7 +43,7 @@ export default Ember.Object.extend({
 			value = value + unit;
 		}
 		// escape if necessary
-		if (isHTMLSafe(value)) {
+		if (Ember.String.isHTMLSafe(value)) {
 			value = value.toString();
 		}
 		else

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1"
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
👋 -- We're updating [ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill) to be a "native polyfill". Following the pattern provided by [ember-assign-polyfill](https://github.com/shipshapecode/ember-assign-polyfill) and [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill).

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5
